### PR TITLE
changed theme to furo in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,4 +33,4 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"


### PR DESCRIPTION
Hey team.

We added furo theme to the .toml file, but default theme was still being referenced in the conf.py file. the theme was adjusted to furo.

Let's see if this fixes the error on read the docs.