### PR TITLE
fix: Feedback for missing_section tests documentation 

### DIFF
--- a/tests/test_missing_section.py
+++ b/tests/test_missing_section.py
@@ -21,6 +21,7 @@ from dsresumatch.sections_check import missing_section
     ],
 )
 def test_missing_section_valid_cases(clean_text, add_benchmark_sections, expected_output):
+    """Tests valid inputs with various combinations of resume text and benchmark sections."""
     assert set(missing_section(clean_text, add_benchmark_sections)) == expected_output
 
 
@@ -33,10 +34,12 @@ def test_missing_section_valid_cases(clean_text, add_benchmark_sections, expecte
     ],
 )
 def test_missing_section_invalid_cases(clean_text, add_benchmark_sections, expected_exception):
+    """Tests invalid inputs where TypeError is expected."""
     with pytest.raises(expected_exception):
         missing_section(clean_text, add_benchmark_sections)
 
 def test_missing_section_warning_empty_text():
+    """Tests warning behavior when an empty string is passed as the resume text."""
     clean_text = ""
     expected_output = ["Skills", "Education", "Work Experience", "Contact"]
     with pytest.warns(UserWarning, match="The provided resume text is an empty string. Returning all benchmark sections as missing."):


### PR DESCRIPTION
I have included documentation for the `missing_section()` tests suite. This is part of the feedback #83 from Milestone 2.