### PR TITLE
Fix/missing section

### DIFF
--- a/docs/example.ipynb
+++ b/docs/example.ipynb
@@ -150,7 +150,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Adding Sections\n",
+    "### Include more sections for checking.\n",
+    "\n",
+    "Here, we can use `add_benchmark_sections` argument to supply additional sections to include into the `missing_section()` function for checking. For example:\n",
     "\n",
     "Daniel saw an article that says \"Personal Statement\" and \"Volunteer\" are one of the key sections in a resume. Now he wants to include the two additional sections into the function to check if they are present."
    ]
@@ -442,7 +444,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pycounts",
+   "display_name": "dsresumatch",
    "language": "python",
    "name": "python3"
   },

--- a/docs/example.ipynb
+++ b/docs/example.ipynb
@@ -174,10 +174,10 @@
     }
    ],
    "source": [
-    "# Addtional sections check use case:\n",
+    "# Additional sections check use case:\n",
     "add_section_check = missing_section(resume_text, add_benchmark_sections=[\"Personal Statement\", \"Volunteer\"])\n",
     "\n",
-    "# Print the missing sections with the addtional sections included\n",
+    "# Print the missing sections with the additional sections included\n",
     "add_section_check"
    ]
   },
@@ -185,7 +185,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After including the addtional sections using the `add_benchmark_sections` argument in the `missing_section()` function, it is found that \"Personal Statement\" is present in Daniel's resume but \"Volunteer\", \"Contact\", \"Work Experience\" and \"Skills\" are missing. "
+    "After including the additional sections using the `add_benchmark_sections` argument in the `missing_section()` function, it is found that \"Personal Statement\" is present in Daniel's resume but \"Volunteer\", \"Contact\", \"Work Experience\" and \"Skills\" are missing. "
    ]
   },
   {
@@ -285,13 +285,13 @@
     }
    ],
    "source": [
-    "# Addtional sections check use case: \n",
+    "# Additional sections check use case: \n",
     "add_keywords_check1 = evaluate_keywords(resume_text, keywords=[\"hyperparameter\", \"effeciency\", \"performance metrics\", \"A/B testing\"])\n",
     "\n",
     "# Sorting keywords to view them alphabetically\n",
     "add_keywords_check1.sort()\n",
     "\n",
-    "# Print the missing keywords with the addtional keywords included\n",
+    "# Print the missing keywords with the additional keywords included\n",
     "add_keywords_check1"
    ]
   },
@@ -321,10 +321,10 @@
     }
    ],
    "source": [
-    "# Addtional sections check use case with use_only_supplied_keywords set to \"True\": \n",
+    "# Additional sections check use case with use_only_supplied_keywords set to \"True\": \n",
     "add_keywords_check2 = evaluate_keywords(resume_text, keywords=[\"Bachelor’s degree\", \"Math\", \"Computer Science\"], use_only_supplied_keywords=True)\n",
     "\n",
-    "# Print the missing keywords with the addtional keywords included\n",
+    "# Print the missing keywords with the additional keywords included\n",
     "add_keywords_check2"
    ]
   },

--- a/src/dsresumatch/sections_check.py
+++ b/src/dsresumatch/sections_check.py
@@ -5,7 +5,7 @@ def missing_section(clean_text, add_benchmark_sections=None):
     """
     Identifies the sections missing from the resume based on the benchmark sections.
 
-    Parameters:
+    Parameters
     ----------
     clean_text : str
         The text extracted from the resume.
@@ -15,29 +15,29 @@ def missing_section(clean_text, add_benchmark_sections=None):
         Defaults to None. If a single string is provided, it will be treated as 
         a list with one element.
 
-    Returns:
+    Returns
     -------
     list of str
         A list of section names from the benchmark that are not present in the resume.
 
-    Examples:
+    Examples
     --------
-    # Example 1: With additional benchmark sections as a list
-    clean_text = "Skills: Python, Machine Learning\nEducation: B.Sc. in CS"
-    add_benchmark_sections = ["Work Experience", "Contact"]
-    missing = missing_section(clean_text, add_benchmark_sections)
-    # Output: ['Work Experience', 'Contact']
+    Example 1: With additional benchmark sections as a list
+    >>> clean_text = "Skills: Python, Machine Learning\nEducation: B.Sc. in CS"
+    >>> add_benchmark_sections = ["Work Experience", "Contact"]
+    >>> missing = missing_section(clean_text, add_benchmark_sections)
+    Output: ['Work Experience', 'Contact']
 
-    # Example 2: With additional benchmark sections as a single string
-    clean_text = "Skills: Python, Machine Learning\nEducation: B.Sc. in CS"
-    add_benchmark_sections = "Projects"
-    missing = missing_section(clean_text, add_benchmark_sections)
-    # Output: ['Work Experience', 'Contact', 'Projects']
+    Example 2: With additional benchmark sections as a single string
+    >>> clean_text = "Skills: Python, Machine Learning\nEducation: B.Sc. in CS"
+    >>> add_benchmark_sections = "Projects"
+    >>> missing = missing_section(clean_text, add_benchmark_sections)
+    Output: ['Work Experience', 'Contact', 'Projects']
 
-    # Example 3: Without additioinal benchmark sections
-    clean_text = "Skills: Python, Machine Learning\nEducation: B.Sc. in CS"
-    missing = missing_section(clean_text)
-    # Output: ['Work Experience', 'Contact']
+    Example 3: Without additioinal benchmark sections
+    >>> clean_text = "Skills: Python, Machine Learning\nEducation: B.Sc. in CS"
+    >>> missing = missing_section(clean_text)
+    Output: ['Work Experience', 'Contact']
     """
     # Chek if 'clean_text' is an empty string
     if clean_text == "":

--- a/tests/test_missing_section.py
+++ b/tests/test_missing_section.py
@@ -31,6 +31,8 @@ def test_missing_section_valid_cases(clean_text, add_benchmark_sections, expecte
     [
         (None, ["Skills", "Education"], TypeError),
         ("Skills: Python\nEducation: CS", 123, TypeError),
+        ("Skills: Python\nEducation: CS", True, TypeError),
+        ("Skills: Python\nEducation: CS", False, TypeError)
     ],
 )
 def test_missing_section_invalid_cases(clean_text, add_benchmark_sections, expected_exception):


### PR DESCRIPTION
Hi team, I have addressed the following feedback regarding `missing_section()` function:
- The "add sections" confused me for a second. Consider clarifying the fact that you are adding checks to the default section checks. #85 
- In the sections_check file, you should consider the edge case of the add_benchmark_sections being a list of integers or booleans ect. #86 
- There were a few spelling errors, particularly with the word "Additional" in the tutorial. #87 
- Please check if the docstrings are formatted properly, for example, for missing_section the formatting in the documentation seems messed up such that Sphinx is not able to render the documentation properly (an example of a well-formatted docstring is resume_score) #88 





