### PR TITLE
Addressed the feedbacks from peer reviews and TAs

### DIFF
--- a/src/dsresumatch/pdf_cv_processing.py
+++ b/src/dsresumatch/pdf_cv_processing.py
@@ -101,6 +101,8 @@ def count_words_in_pdf(file_path):
     """
     if not isinstance(file_path, str):
         raise TypeError("file_path must be a string representing the file path")
+    if not file_path.lower().endswith(".pdf"):
+        raise ValueError("file_path must point to a PDF file")
     
     pdf_text = read_pdf(file_path)
     cleaned_text = clean_text(pdf_text)

--- a/src/dsresumatch/pdf_cv_processing.py
+++ b/src/dsresumatch/pdf_cv_processing.py
@@ -26,6 +26,9 @@ def read_pdf(file_path):
     >>> read_pdf("cv.pdf")
     'Work Experience\nSoftware Developer at XYZ Corp.\nEducation\nBachelor of Science in Computer Science\n'
     """
+    if not isinstance(file_path, str):
+        raise TypeError("file_path must be a string representing the file path")
+    
     text_content = []
     try:
         with open(file_path, 'rb') as pdf_file:
@@ -56,6 +59,10 @@ def clean_text(raw_text):
     >>> clean_text("Work Experience: Software Developer at XYZ Corp!")
     'work experience software developer xyz corp'
     """
+
+    if not isinstance(raw_text, str):
+        raise TypeError("raw_text must be a string")
+    
     # Convert to lowercase
     raw_text = raw_text.lower()
     # Remove punctuation
@@ -88,6 +95,9 @@ def count_words_in_pdf(file_path):
     >>> count_words_in_pdf("cv.pdf")
     Counter({'work': 1, 'experience': 1, 'software': 1, 'developer': 1, 'at': 1, 'xyz': 1, 'corp': 1, 'education': 1, 'bachelor': 1, 'of': 1, 'science': 1, 'in': 1, 'computer': 1})
     """
+    if not isinstance(file_path, str):
+        raise TypeError("file_path must be a string representing the file path")
+    
     pdf_text = read_pdf(file_path)
     cleaned_text = clean_text(pdf_text)
     word_list = cleaned_text.split()

--- a/src/dsresumatch/pdf_cv_processing.py
+++ b/src/dsresumatch/pdf_cv_processing.py
@@ -28,6 +28,8 @@ def read_pdf(file_path):
     """
     if not isinstance(file_path, str):
         raise TypeError("file_path must be a string representing the file path")
+    if not file_path.lower().endswith(".pdf"):
+        raise ValueError("file_path must point to a PDF file")
     
     text_content = []
     try:
@@ -36,9 +38,11 @@ def read_pdf(file_path):
             for page in reader.pages:
                 text_content.append(page.extract_text())
         return "".join(text_content).replace("\n", "")
+    except FileNotFoundError as e:
+        raise FileNotFoundError(f"The file {file_path} does not exist.") from e
     except Exception as e:
         raise ValueError(f"Error reading the PDF file: {e}")
-
+    
 
 def clean_text(raw_text):
     """

--- a/tests/test_pdf_cv_processing.py
+++ b/tests/test_pdf_cv_processing.py
@@ -46,6 +46,13 @@ def test_read_pdf():
 def test_clean_text():
     """Test cases for clean_text function"""
 
+    try:
+        clean_text(123)  # type: ignore
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Expected TypeError")
+
     raw_text = "Work Experience: Software Developer at XYZ Corp!"
     expected_result = "work experience software developer xyz corp"
     result = clean_text(raw_text)
@@ -54,7 +61,13 @@ def test_clean_text():
 
 def test_count_words_in_pdf():
     """Test cases for count_words_in_pdf function"""
-
+    
+    try:
+        count_words_in_pdf(123)  # type: ignore
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Expected TypeError")
     # Simulate the output of read_pdf and clean_text
     pdf_text = "Work Experience: Software Developer at XYZ Corp!"
     expected_counter = Counter({
@@ -71,7 +84,14 @@ def test_count_words_in_pdf():
 
 def test_clean_text_with_empty_string():
     """Test case for clean_text with an empty string"""
-
+    
+    try:
+        clean_text(None)  # type: ignore
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Expected TypeError")
+    
     raw_text = ""
     expected_result = ""
     result = clean_text(raw_text)
@@ -80,7 +100,13 @@ def test_clean_text_with_empty_string():
 
 def test_count_words_in_pdf_with_empty_content():
     """Test case for count_words_in_pdf with an empty PDF"""
-
+    try:
+        count_words_in_pdf(None)  # type: ignore
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Expected TypeError")
+    
     pdf_text = ""
     result = count_words_in_pdf("tests/empty.pdf")
     assert result == Counter()  # Empty Counter for empty content

--- a/tests/test_pdf_cv_processing.py
+++ b/tests/test_pdf_cv_processing.py
@@ -1,6 +1,9 @@
 from collections import Counter
 from dsresumatch.pdf_cv_processing import read_pdf, clean_text, count_words_in_pdf
 
+with open("tests/corrupt.pdf", "wb") as f:
+    f.write(b"%PDF-1.4\n%Invalid content")
+
 def test_read_pdf():
     """Test cases for read_pdf function"""
     
@@ -43,6 +46,15 @@ def test_read_pdf():
     else:
         raise AssertionError("Expected ValueError")
 
+def test_read_pdf_with_invalid_pdf():
+    """Test case for read_pdf when an invalid PDF file is provided"""
+    try:
+        read_pdf("tests/corrupt.pdf")
+    except ValueError as e:
+        assert "Error reading the PDF file" in str(e)
+    else:
+        raise AssertionError("Expected ValueError")
+
 def test_clean_text():
     """Test cases for clean_text function"""
 
@@ -68,6 +80,14 @@ def test_count_words_in_pdf():
         pass
     else:
         raise AssertionError("Expected TypeError")
+    
+    try:
+        count_words_in_pdf("tests/dummy.txt")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError")
+    
     # Simulate the output of read_pdf and clean_text
     pdf_text = "Work Experience: Software Developer at XYZ Corp!"
     expected_counter = Counter({

--- a/tests/test_pdf_cv_processing.py
+++ b/tests/test_pdf_cv_processing.py
@@ -3,11 +3,12 @@ from dsresumatch.pdf_cv_processing import read_pdf, clean_text, count_words_in_p
 
 def test_read_pdf():
     """Test cases for read_pdf function"""
+    
     # Normal case
     result = read_pdf("tests/dummy.pdf")
     assert result == "Work Experience: Software Developer at XYZ Corp! "
     
-# Non-string input cases
+    # Non-string input cases
     try:
         read_pdf(123)
     except TypeError:
@@ -43,6 +44,8 @@ def test_read_pdf():
         raise AssertionError("Expected ValueError")
 
 def test_clean_text():
+    """Test cases for clean_text function"""
+
     raw_text = "Work Experience: Software Developer at XYZ Corp!"
     expected_result = "work experience software developer xyz corp"
     result = clean_text(raw_text)
@@ -50,6 +53,8 @@ def test_clean_text():
 
 
 def test_count_words_in_pdf():
+    """Test cases for count_words_in_pdf function"""
+
     # Simulate the output of read_pdf and clean_text
     pdf_text = "Work Experience: Software Developer at XYZ Corp!"
     expected_counter = Counter({
@@ -65,6 +70,8 @@ def test_count_words_in_pdf():
     assert result == expected_counter
 
 def test_clean_text_with_empty_string():
+    """Test case for clean_text with an empty string"""
+
     raw_text = ""
     expected_result = ""
     result = clean_text(raw_text)
@@ -72,12 +79,16 @@ def test_clean_text_with_empty_string():
 
 
 def test_count_words_in_pdf_with_empty_content():
+    """Test case for count_words_in_pdf with an empty PDF"""
+
     pdf_text = ""
     result = count_words_in_pdf("tests/empty.pdf")
     assert result == Counter()  # Empty Counter for empty content
 
 
 def test_clean_text_removes_punctuation():
+    """Test case for clean_text ensuring punctuation is removed"""
+
     raw_text = "Hello, world! Python programming is fun."
     expected_result = "hello world python programming fun"
     result = clean_text(raw_text)
@@ -85,6 +96,8 @@ def test_clean_text_removes_punctuation():
 
 
 def test_clean_text_removes_stopwords():
+    """Test case for clean_text ensuring stopwords are removed"""
+
     raw_text = "This is a test for removing stopwords from text"
     expected_result = "test removing stopwords text"
     result = clean_text(raw_text)

--- a/tests/test_pdf_cv_processing.py
+++ b/tests/test_pdf_cv_processing.py
@@ -85,17 +85,29 @@ def test_count_words_in_pdf():
 def test_clean_text_with_empty_string():
     """Test case for clean_text with an empty string"""
     
-    try:
-        clean_text(None)  # type: ignore
-    except TypeError:
-        pass
-    else:
-        raise AssertionError("Expected TypeError")
+    for invalid_input in [None, [], {}]:
+        try:
+            clean_text(invalid_input)  # type: ignore
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("Expected TypeError")
     
     raw_text = ""
     expected_result = ""
     result = clean_text(raw_text)
     assert result == expected_result
+
+def test_clean_text_with_non_string_input():
+    """Test case for clean_text with a list of strings and other non-string inputs"""
+    
+    for invalid_input in [["hello", "world"], 42, 3.14, True]:
+        try:
+            clean_text(invalid_input)  # type: ignore
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("Expected TypeError")
 
 
 def test_count_words_in_pdf_with_empty_content():

--- a/tests/test_pdf_cv_processing.py
+++ b/tests/test_pdf_cv_processing.py
@@ -1,9 +1,46 @@
 from collections import Counter
 from dsresumatch.pdf_cv_processing import read_pdf, clean_text, count_words_in_pdf
 
-def test_read_pdf(): 
+def test_read_pdf():
+    """Test cases for read_pdf function"""
+    # Normal case
     result = read_pdf("tests/dummy.pdf")
     assert result == "Work Experience: Software Developer at XYZ Corp! "
+    
+# Non-string input cases
+    try:
+        read_pdf(123)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Expected TypeError")
+    
+    try:
+        read_pdf(None)
+    except TypeError:
+        pass
+    else:
+        raise AssertionError("Expected TypeError")
+    
+    # Non-existent file case
+    try:
+        read_pdf("non_existent.pdf")
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("Expected FileNotFoundError")
+    
+    # Empty PDF case
+    result = read_pdf("tests/empty.pdf")
+    assert result == " "
+    
+    # Incorrect file type case
+    try:
+        read_pdf("tests/dummy.txt")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError")
 
 def test_clean_text():
     raw_text = "Work Experience: Software Developer at XYZ Corp!"


### PR DESCRIPTION
- In the pdf_cv_processing file, you should consider the edge cases of read_pdf(file_path) and count_words_in_pdf(file_path) functions got invalid file path as inputs.
- In the pdf_cv_processing file, you should consider some edge cases of the clean_text function got a list of strings or a none string object as inputs.
- https://github.com/UBC-MDS/dsresumatch/issues/66